### PR TITLE
fix carousel weirdness + remove extra p elements from empty lines - Mar 4, 2026

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -13,7 +13,6 @@
 
 .carousel {
   position: relative;
-  overflow: hidden;
 }
 
 .carousel .carousel-slides-container {

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -79,6 +79,30 @@ function createSlide(row, slideIndex, carouselId) {
 
   row.querySelectorAll(':scope > div').forEach((column, colIdx) => {
     column.classList.add(`carousel-slide-${colIdx === 0 ? 'image' : 'content'}`);
+
+    // Art direction: when the image column has two <picture> elements,
+    // merge them into one <picture> with a desktop <source> and mobile <img>.
+    if (colIdx === 0) {
+      const pictures = column.querySelectorAll('picture');
+      if (pictures.length === 2) {
+        const mobileImg = pictures[0].querySelector('img');
+        const desktopImg = pictures[1].querySelector('img');
+        if (mobileImg && desktopImg) {
+          const picture = document.createElement('picture');
+          const source = document.createElement('source');
+          source.media = '(min-width: 768px)';
+          source.srcset = desktopImg.src;
+          source.width = desktopImg.getAttribute('width') || desktopImg.naturalWidth;
+          source.height = desktopImg.getAttribute('height') || desktopImg.naturalHeight;
+          picture.append(source);
+          const img = mobileImg.cloneNode(true);
+          picture.append(img);
+          pictures[0].replaceWith(picture);
+          pictures[1].remove();
+        }
+      }
+    }
+
     slide.append(column);
   });
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -165,6 +165,8 @@ function mergeArtDirectionPictures(container) {
       const source = document.createElement('source');
       source.media = '(min-width: 768px)';
       source.srcset = desktopImg.src;
+      source.width = desktopImg.getAttribute('width') || desktopImg.naturalWidth;
+      source.height = desktopImg.getAttribute('height') || desktopImg.naturalHeight;
       picture.append(source);
       picture.append(mobileImg.cloneNode(true));
 


### PR DESCRIPTION
Automated migration updates generated by Experience Modernization Agent.

Changed files (3):
- blocks/carousel/carousel.css
- blocks/carousel/carousel.js
- scripts/scripts.js

## Test URLs:

**footer**
- Before: https://aem-20260304-1232--poc-ip--aemdemos.aem.page/footer
- After: https://aem-20260304-1543--poc-ip--aemdemos.aem.page/footer

**index**
- Before: https://aem-20260304-1232--poc-ip--aemdemos.aem.page/index
- After: https://aem-20260304-1543--poc-ip--aemdemos.aem.page/index

**nav**
- Before: https://aem-20260304-1232--poc-ip--aemdemos.aem.page/nav
- After: https://aem-20260304-1543--poc-ip--aemdemos.aem.page/nav

